### PR TITLE
Use pytest-json-report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-html
+pytest-json-report
 luma.oled==3.8.1
 rpi.gpio==0.7.1a4
 gpiozero==1.6.2

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     install_requires=[
         "pytest",
         "pytest-html",
+        "pytest-json-report",
         "luma.oled==3.8.1",
         "rpi.gpio==0.7.1a4",
         "gpiozero==1.6.2",


### PR DESCRIPTION
Use pytest-json-report and analyze the response rather than manually defining tests. This PR enables automatic test discovery in the `tests` folder, and printing of the results to the OLED without also changing `testing.py`.