### PR TITLE
fix unhandled exception in vl805 test and add test error warnings

### DIFF
--- a/hwtest/testing.py
+++ b/hwtest/testing.py
@@ -190,8 +190,11 @@ def print_pytest_summary(summary):
     """print pytest summary to oled"""
     ok = summary.get("passed", 0)
     fail = summary.get("failed", 0)
+    error = summary.get("error", 0)
     total = summary.get("total", 0)
     if fail > 0:
-        TERMINAL.println(f"{fail} OF {total} FAILED!")
+        TERMINAL.println(f"{fail} OF {total} FAILED!!!")
+    if error > 0:
+        TERMINAL.println(f"{error} TESTS ERRORED!!!")
     if ok == total:
-        TERMINAL.println(f"ALL {total} TESTS PASS")
+        iconized_print("\uf164", f"ALL {total} TESTS PASS")

--- a/hwtest/tests/vl805_test.py
+++ b/hwtest/tests/vl805_test.py
@@ -1,3 +1,5 @@
+import shutil
+
 from hwtest.tests.helpers import run_command
 
 
@@ -9,6 +11,8 @@ def test_vl805_fw():
 
     Expects: VL805 FW version: 000138a1
     """
-    resp = run_command(["vl805"])
+    if shutil.which("vl805") is not None:
+        resp = run_command(["vl805"])
 
-    assert "000138a1" in resp
+        assert "000138a1" in resp
+    assert False


### PR DESCRIPTION
* Fixes an unhandled exception in the vl805 test when `vl805` isn't present on the host.
* Displays a warning on the OLED when there is an error in a test (like an uncaught exceptoin).

![image](https://user-images.githubusercontent.com/13954434/147392101-bdf45fac-75a6-46ae-bb02-f47a832ca7a0.png)
