### PR TITLE
remove test on invalid check for speed. tester may be using 100 Mbit …

### DIFF
--- a/hwtest/automated/ethernet_test.py
+++ b/hwtest/automated/ethernet_test.py
@@ -59,17 +59,3 @@ def test_eth0_up(eth0_data):
         False - any other output
     """
     assert eth0_data.operstate == "UP"
-
-
-def test_eth0_speed(eth0_data):
-    """
-    Test commands:
-        ip address
-        cat /sys/class/net/{intf}/duplex
-        cat /sys/class/net/{intf}/speed
-
-    Results:
-        True - eth0 speed is "1000"
-        False - any other output
-    """
-    assert eth0_data.speed == 1000


### PR DESCRIPTION
…versus 1 GbE capable switch during build

--
          <td class="col-result">Failed</td>
          <td class="col-name">automated/ethernet_test.py::test_eth0_speed</td>
          <td class="col-duration">0.02</td>

There is a PoE switch which support 100Mbit only.