### PR TITLE
remove hwclock -r test and add /dev/rtc0 exists test

### DIFF
--- a/hwtest/automated/rtc_test.py
+++ b/hwtest/automated/rtc_test.py
@@ -14,18 +14,37 @@ def test_rtc_pcf85063_mod():
     assert is_module_present("rtc_pcf85063") == True
 
 
-def test_rtc_hwclock():
+def test_rtc0_exists():
     """
-    Test command:
-        hwclock -r
+        Test command:
+        ls /dev/rtc0
 
     Expect:
-        exit value is 0 (we got a timestamp)
+        exit value is 0 (/dev/rtc0 exists)
 
     Not Expected:
-        exit value is 1 (cannot access hardware clock for example)
+        exit value is 2 (/dev/rtc0 does not exist)
     """
 
-    exit_value = run_command(["hwclock", "-r"], return_exit_values=True)
+    exit_value = run_command(["ls", "/dev/rtc0"], return_exit_values=True)
 
     assert exit_value == 0
+
+################
+# INVALID TEST #
+################
+# def test_rtc_hwclock():
+#     """
+#     Test command:
+#         hwclock -r
+#
+#     Expect:
+#         exit value is 0 (we got a timestamp)
+#
+#     Not Expected:
+#         exit value is 1 (cannot access hardware clock for example)
+#     """
+#
+#     exit_value = run_command(["hwclock", "-r"], return_exit_values=True)
+#
+#     assert exit_value == 0


### PR DESCRIPTION
Problem with `hwclock` in during assembly:

```bash
# hwclock -vv
hwclock from util-linux 2.36.1
System Time: 1641002098.618969
Trying to open: /dev/rtc0
Using the rtc interface to the clock.
Assuming hardware clock is kept in UTC time.
Waiting for clock tick...
ioctl(4, RTC_UIE_ON, 0): Invalid argument
Waiting in loop for time from /dev/rtc0 to change
hwclock: ioctl(RTC_RD_TIME) to /dev/rtc0 to read the time failed: Invalid argument
...synchronization failed
```

PR removes the `hwclock -r` test which is likely getting a non-zero return value.

PR adds an existence test for `/dev/rtc0`:

```bash
wlanpi@wlanpi:~ $ ls /dev/rtc0
/dev/rtc0
wlanpi@wlanpi:~ $ echo $?
0
```