### PR TITLE
Release wlanpi-hwtest 1.1.0-beta4 for Debian trixie

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-hwtest (1.1.0-beta4) unstable; urgency=medium
+
+  * Rebuild to publish packages for Debian trixie to packagecloud.
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Wed, 15 Jul 2026 03:20:17 -0400
+
 wlanpi-hwtest (1.1.0-beta3) unstable; urgency=high
 
   * Security: Pillow 12.3.0 (CVE fixes: PSD OOB writes, FITS decompression


### PR DESCRIPTION
Bumps `debian/changelog` (`1.1.0-beta3` -> `1.1.0-beta4`) to trigger a trixie build and publish to packagecloud.

The CI matrix already targets trixie, but no package had been published since that switch (deploy only fires on `debian/changelog` changes), so no trixie `.deb` exists in packagecloud yet. This rebuild produces one. No source changes.